### PR TITLE
Fixing birthday day off on apple devices

### DIFF
--- a/src/backend/kopano/mapiprovider.php
+++ b/src/backend/kopano/mapiprovider.php
@@ -119,6 +119,21 @@ class MAPIProvider {
                 }
             }
         }
+        
+        //If the client is an apple device
+        //example return from $_SERVER['HTTP_USER_AGENT'] -> 'Apple-iPad6C3/1606.203'
+        //if (stripos($_SERVER['HTTP_USER_AGENT'], 'apple') === TRUE) {
+            //Then add 14 hours to fix the 'day off' problem on apple devices
+            //TODO get server timezone and add 12 hours to the offset
+            $secondstoadd = 50400;//60 * 60 * 14
+            //TODO check for birthday and anniversary is set before applying changes
+            if (isset($message->birthday)) {
+                $message->birthday = $message->birthday + $secondstoadd;
+            }
+            if (isset($message->anniversary)) {
+                $message->anniversary = $message->anniversary + $secondstoadd;
+            }
+        //}
 
         return $message;
     }


### PR DESCRIPTION
Apple device do not interprete the timezone on birthdays and anniversaries correctly.
By adding 14 hours the timestamp is set to the actual day at 12am.
This is the timestamp apple uses when sending contacts to the server.

TODO: to prevent other devices from not functioning correctly anymore this fix should only be applied when client is an apple device!